### PR TITLE
add new organizer to Hamburg whitelabel

### DIFF
--- a/config/whitelabel.yml
+++ b/config/whitelabel.yml
@@ -14,6 +14,7 @@
   organizers:
   - lindtdev
   - janz93
+  - JoschkaSchulz
   location:
     :zoom: 12
     :lat: 53.56544


### PR DESCRIPTION
Therefore that I'm joining the orga team for the Hamburg Usergroup, I thought it would be a good idea to add me to the organizer list