### PR TITLE
fix: badge positioning in safari desktop

### DIFF
--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -375,3 +375,7 @@ footer
         max-width: 100%
         display: block
         margin: auto
+
+// boostrap sadly overrides it's own card(display:flex) with .card-columns .card(display:inline-block), which breaks the badge layout in safari
+.card-columns .card
+  display: flex


### PR DESCRIPTION
Before: 
![Screenshot 2024-08-06 at 22 46 24](https://github.com/user-attachments/assets/3b091fe0-dd31-4354-b6de-70b72c12e33d)
After:

![Screenshot 2024-08-06 at 22 46 35](https://github.com/user-attachments/assets/cf40dfef-c52c-4e11-9a7b-729f024f008a)
