### PR TITLE
chore: replace /etc/hosts change with RFC6761 localhost

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,13 +28,13 @@ module ApplicationHelper
   end
 
   def label_auth_url(provider)
-    host = Rails.env.development? ? "http://#{Whitelabel[:label_id]}.onruby.test:3000" : Whitelabel[:canonical_url]
+    host = Rails.env.development? ? "http://#{Whitelabel[:label_id]}.onruby.localhost:3000" : Whitelabel[:canonical_url]
 
     "#{host}/auth/#{provider}?origin=#{CGI.escape(params[:origin]) if params[:origin]}"
   end
 
   def label_url(label)
-    host = Rails.env.development? ? "#{label.label_id}.onruby.test" : label.canonical_url
+    host = Rails.env.development? ? "#{label.label_id}.onruby.localhost" : label.canonical_url
     root_url(host:)
   end
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,7 +2,7 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
-  config.hosts << /.*onruby\.test.*/
+  config.hosts << /.*onruby\.localhost.*/
 
   # In the development environment your application's code is reloaded any time
   # it changes. This slows down response time but is perfect for development

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -7,7 +7,7 @@ namespace :data do
       5.times { FactoryBot.create(:event, date: rand(100).days.ago) }
       5.times { FactoryBot.create(:participant) }
     end
-    puts 'now open your browser at http://hamburg.onruby.test:3000/'
+    puts 'now open your browser at http://hamburg.onruby.localhost:3000/'
   end
 
   task setup: ['environment', 'db:migrate'] do

--- a/lib/tasks/fork.rake
+++ b/lib/tasks/fork.rake
@@ -31,6 +31,6 @@ namespace :fork do
     FileUtils.mkdir_p(Rails.root.join("app/assets/javascripts/labels/#{usergroup.label_id}"))
     FileUtils.touch(Rails.root.join("app/assets/javascripts/labels/#{usergroup.label_id}/.gitkeep"))
 
-    puts "now add '127.0.0.1 #{name}.onruby.test' to your /etc/hosts, run 'script/server' and run 'open #{name}.onruby.test:3000'"
+    puts "now add '127.0.0.1 #{name}.onruby.localhost' to your /etc/hosts, run 'script/server' and run 'open #{name}.onruby.localhost:3000'"
   end
 end

--- a/readme.md
+++ b/readme.md
@@ -74,10 +74,12 @@ script/in_docker bundle exec rspec spec/requests/labels_spec.rb
 
 #### Add usergroup hostnames to `/etc/hosts`
 
+Note: This step is currently only necessary for Safari, all other browsers thread localhost as wildcard domain.
+
 Add all supported subdomains to your `/etc/hosts` file:
 
 ```
-127.0.0.1    www.onruby.test hamburg.onruby.test cologne.onruby.test berlin.onruby.test madridrb.onruby.test andalucia.onruby.test
+127.0.0.1    www.onruby.test hamburg.onruby.localhost cologne.onruby.localhost berlin.onruby.localhost madridrb.onruby.localhost andalucia.onruby.localhost
 ```
 
 #### Visit the site


### PR DESCRIPTION
As described in https://www.rfc-editor.org/rfc/rfc6761#section-6.3, anything "ending" with .localhost is considered localhost, so we can use http://$label.onruby.localhost:3000 for development purposes without changing /etc/hosts at all.

unless we want to develop with safari, which doesn't support this right now. 