### PR TITLE
fix: Kernel#open for URL got deprecated with 2.7

### DIFF
--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'uri'
+
 class ImagesController < ActionController::Base
   PUBLIC_MOUNTS = {
     'User' => :image,
@@ -17,7 +19,7 @@ class ImagesController < ActionController::Base
       url = model.send(attribute_name)
 
       if url.present?
-        open(url) do |f|
+        URI.open(url) do |f|
           send_data(f.read, filename:, disposition: :inline, content_type: f.content_type)
         end
       else


### PR DESCRIPTION
![Screenshot 2024-09-30 at 22 11 41](https://github.com/user-attachments/assets/55d2c9c3-b076-4b65-ac51-7d17908812d7)
