### PR TITLE
fix: changed administrate api

### DIFF
--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -68,17 +68,19 @@ as well as a link to its edit page.
 </header>
 
 <section class="main-content__body">
-  <dl>
-    <% page.attributes.each do |attribute| %>
-      <dt class="attribute-label" id="<%= attribute.name %>">
-      <%= t(
-        "helpers.label.#{resource_name}.#{attribute.name}",
-        default: attribute.name.titleize,
-      ) %>
-      </dt>
+  <dl>    
+    <% page.attributes.each do |_title, attributes| %>
+      <% attributes.each do |attribute| %>
+        <dt class="attribute-label" id="<%= attribute&.name %>">
+        <%= t(
+          "helpers.label.#{resource_name}.#{attribute&.name}",
+          default: attribute.name.titleize,
+        ) %>
+        </dt>
 
-      <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
-          ><%= render_field attribute, page: page %></dd>
+        <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+            ><%= render_field attribute, page: page %></dd>
+      <% end %>
     <% end %>
   </dl>
 </section>


### PR DESCRIPTION
After saving an event, an error is displayed. This error occurs on the show page of the event. It seems that the administrate api has changed and the attributes are now nested in a hash with no given key.

This commit returns the correct attributes for the show page and resolves the attributes correctly.

Before:
![image](https://github.com/user-attachments/assets/e755b3d6-0b80-4653-8a63-a7b11947bfd0)

After:
![image](https://github.com/user-attachments/assets/d50a65b5-709d-4c0a-bffd-97dcd5a3970e)
