### PR TITLE
chore: remove twitter from available login_providers

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -13,7 +13,7 @@ module ApplicationHelper
   end
 
   def login_providers
-    %w[twitter github google_oauth2]
+    %w[github google_oauth2]
   end
 
   def whitelabel_stylesheet_link_tag


### PR DESCRIPTION
I don't think we intend to reintegrate it, and it doesn't work right now. Lets remove it then?