### PR TITLE
fix: change the name of one of the dresdenrb organizers to the nickname

### DIFF
--- a/config/whitelabel.yml
+++ b/config/whitelabel.yml
@@ -520,7 +520,7 @@
   email: rug-dd@mailbox.org
   organizers:
   - Maik Arnold
-  - Richard Böhme
+  - richardboehme
   - Sarah Franke
   location:
     :zoom: 14


### PR DESCRIPTION
I think all the three names are wrong, in the config. I fixed the one I know the other two aren't signed up. This way there is at least one Organizer visiable.