### PR TITLE
chore: add appsignal plugin to puma

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -41,3 +41,4 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart
+plugin :appsignal


### PR DESCRIPTION
This adds the appsignal plugin to puma. This way we build up metrics to our puma server in cases we need to profile or debug something puma worker related.