### PR TITLE
Allow login for old Twitter users with same email

### DIFF
--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -22,6 +22,8 @@ class Authorization < ApplicationRecord
 
   def self.user_for_new_authorization(auth)
     email = auth.dig('info', 'email')
+    return if email.blank?
+
     users_with_email = User.where(email:)
     return unless users_with_email.count == 1
 

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -43,6 +43,6 @@ class Authorization < ApplicationRecord
     rescue Date::Error, TypeError
       DEFAULT_TWITTER_USER_FALLBACK_DEADLINE
     end
-    Time.zone.today <= deadline
+    deadline.future?
   end
 end

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -14,9 +14,20 @@ class Authorization < ApplicationRecord
     if authorization.present?
       authorization.user.update_from_auth! auth
     else
-      user = existing_user || User.create_from_hash!(auth)
+      user = existing_user || user_for_new_authorization(auth) || User.create_from_hash!(auth)
       authorization = user.authorizations.create! provider:, uid:
     end
     authorization
+  end
+
+  def self.user_for_new_authorization(auth)
+    email = auth.dig('info', 'email')
+    users_with_email = User.where(email:)
+    return unless users_with_email.count == 1
+
+    user = users_with_email.first
+    return nil unless user.authorizations.count == 1 && user.authorizations.first.provider == 'twitter'
+
+    user.update_from_auth!(auth)
   end
 end

--- a/app/models/authorization.rb
+++ b/app/models/authorization.rb
@@ -30,7 +30,7 @@ class Authorization < ApplicationRecord
     return unless users_with_email.count == 1
 
     user = users_with_email.first
-    return nil unless user.authorizations.count == 1 && user.authorizations.first.provider == 'twitter'
+    return unless user.authorizations.count == 1 && user.authorizations.first.provider == 'twitter'
 
     user.update_from_auth!(auth)
   end

--- a/readme.md
+++ b/readme.md
@@ -169,6 +169,32 @@ On the admin site we need to:
 - deploy to Heroku
 - add admin privileges to someone for the new RUG
 
+## Users Login
+
+In order to register for events, users need to log in first.
+
+The app uses OAuth for that. At this point, it accepts Twitter [^1], GitHub and Google as valid OAuth providers.
+
+When a user is not currently logged in, selecting one of the login providers creates an account for him/her, attaching this provider as a valid auth mechanism.
+
+When a user is already logged in, selecting another provider will add that auth mechanism to the existing user.
+
+[^1]: As of 2024 Twitter/X has deprecated API v1.1 and Twitter login is not working anymore
+
+### Recovering login for existing users who only had Twitter auth
+
+As a consequence of X deprecating API v1.1, Twitter authentication is not working anymore and registered users that only had defined Twitter as their auth method are left out in the cold.
+
+In order to provide an easy way for these users to access their existing account using another auth provider, the app includes additional logic:
+
+1. If a new session successfully authenticates using a provider that includes email as part of their info.
+2. If a user (and only one user) already exists with that same email
+3. If that user was using Twitter (and only Twitter) as OAuth provider
+
+If all of these conditions are met, then the new provider is added to the existing user and the log in proceeds with that.
+
+If the existing user had other providers already registered, then this logic doesn't kick in, as they can still use one of the others to log in.
+
 ## Website
 
 ![OnRuby Website](https://cl.ly/image/3U0S3b0T0F0x/Screen%20Shot%202014-01-07%20at%2014.16.44.png)

--- a/readme.md
+++ b/readme.md
@@ -191,9 +191,13 @@ In order to provide an easy way for these users to access their existing account
 2. If a user (and only one user) already exists with that same email
 3. If that user was using Twitter (and only Twitter) as OAuth provider
 
-If all of these conditions are met, then the new provider is added to the existing user and the log in proceeds with that.
+If all of these conditions are met, then the new provider is added to the existing user and the login proceeds with that.
 
 If the existing user had other providers already registered, then this logic doesn't kick in, as they can still use one of the others to log in.
+
+As this behaviour could lead to potential account takeovers (if another user had access to an OAuth account with the same email of the original user) there's a deadline after which it will stop working.
+
+The default deadline is the end of year 2024. If needed it can be ajusted by setting the environment variable `TWITTER_USER_FALLBACK_DEADLINE` to a valid date address string (like '2025-06-30').
 
 ## Website
 

--- a/spec/models/authorization_spec.rb
+++ b/spec/models/authorization_spec.rb
@@ -8,4 +8,73 @@ describe Authorization do
       end.to change(User, :count).by(1)
     end.to change(Authorization, :count).by(1)
   end
+
+  describe 'special treatment for stale Twitter users' do
+    let(:existing_twitter_auth) { Authorization.handle_authorization(nil, TWITTER_AUTH_HASH) }
+    let(:existing_twitter_user) { existing_twitter_auth.user }
+
+    before { existing_twitter_user }
+
+    context 'when emails do not match', :aggregate_failures do
+      context 'when nicknames are the same' do
+        it 'raises duplication error' do
+          expect do
+            Authorization.handle_authorization(nil, GITHUB_AUTH_HASH)
+          end.to raise_error(User::DuplicateNickname)
+        end
+      end
+
+      context 'when nicknames are different' do
+        before { existing_twitter_user.update!(nickname: existing_twitter_user.nickname * 2) }
+
+        it 'creates a new user' do
+          gh_user = Authorization.handle_authorization(nil, GITHUB_AUTH_HASH).user
+          expect(gh_user).to be_persisted
+          expect(gh_user).not_to eq(existing_twitter_user)
+        end
+      end
+    end
+
+    context 'when emails match' do
+      before { existing_twitter_user.update!(email: GITHUB_AUTH_HASH.dig('info', 'email')) }
+
+      context 'when email is unique and user has only Twiter auth' do
+        it 'adds the auth to the existing Twitter account', :aggregate_failures do
+          gh_auth = Authorization.handle_authorization(nil, GITHUB_AUTH_HASH)
+          expect(gh_auth.user).to eq(existing_twitter_user)
+          expect(existing_twitter_user.reload.github).to eq(GITHUB_AUTH_HASH.dig('info', 'nickname'))
+        end
+      end
+
+      context 'when several users have the same email' do
+        before { create(:user, email: existing_twitter_user.email) }
+
+        it 'raises duplication error' do
+          expect do
+            Authorization.handle_authorization(nil, GITHUB_AUTH_HASH)
+          end.to raise_error(User::DuplicateNickname)
+        end
+      end
+
+      context 'when the user has other authorizations' do
+        before { create(:authorization, user: existing_twitter_user) }
+
+        it 'raises duplication error' do
+          expect do
+            Authorization.handle_authorization(nil, GITHUB_AUTH_HASH)
+          end.to raise_error(User::DuplicateNickname)
+        end
+      end
+
+      context 'when the user had a single auth but it was not Twitter' do
+        before { existing_twitter_user.authorizations = [create(:authorization)] }
+
+        it 'raises duplication error' do
+          expect do
+            Authorization.handle_authorization(nil, GITHUB_AUTH_HASH)
+          end.to raise_error(User::DuplicateNickname)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/authorization_spec.rb
+++ b/spec/models/authorization_spec.rb
@@ -42,7 +42,7 @@ describe Authorization do
       create(:authorization, provider: 'twitter', user: create(:user, email: nil))
     end
 
-    context 'when emails do not match', :aggregate_failures do
+    context 'when emails do not match' do
       context 'when nicknames are the same' do
         it_behaves_like 'failing with duplicate nickname'
       end
@@ -50,7 +50,7 @@ describe Authorization do
       context 'when nicknames are different' do
         before { existing_twitter_user.update!(nickname: existing_twitter_user.nickname * 2) }
 
-        it 'creates a new user' do
+        it 'creates a new user', :aggregate_failures do
           gh_user = Authorization.handle_authorization(nil, new_auth_hash).user
           expect(gh_user).to be_persisted
           expect(gh_user).not_to eq(existing_twitter_user)
@@ -117,7 +117,7 @@ describe Authorization do
         it_behaves_like 'failing with duplicate nickname'
       end
 
-      context 'when the user had a single auth but it was not Twitter' do
+      context 'when the user has a single auth but it is not Twitter' do
         before { existing_twitter_user.authorizations = [create(:authorization)] }
 
         it_behaves_like 'failing with duplicate nickname'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ RSpec.configure do |config|
   config.include KaminariHelper
   config.include GeocoderHelper
   config.include FactoryBot::Syntax::Methods
+  config.include ActiveSupport::Testing::TimeHelpers
 
   # config.raise_errors_for_deprecations!
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
One possible solution for #1063

As described in the issue mentioned above, with Twitter shutting down our authentication, users that only had that login configured are left out and cannot login. They can try to use different methods, but that means creating a new user.

One suggestion has been to add a new OAuth method based on OTP by email, which seems quite useful, but, still, wouldn't allow these users to connect to their old account.

As a special treatment for these special situation, this PR tries to allow these users to connect to their existing accounts if they log in using a different OAuth method and emails match.

The exact behaviour is:

1. If a new session successfully authenticates using a provider that includes email as part of their info.
2. If a user (and only one user) already exists with that same email
3. If that user was using Twitter (and only Twitter) as OAuth provider

If all of these conditions are met, then the new provider is added to the existing user and the login proceeds with that.

If the existing user had other providers already registered, then this logic doesn't kick in, as they can still use one of the others to log in.

There's still the problem with duplicate nicknames. They are taken from the "username" in the OAuth method, and if they are the same for different methods (for instance, the Twitter handle and the GitHub username are the same), even creating a new account will fail, because of the unique nicknames constrain. This could be a source of confusion and I think we should at least try to use a derived nickname (like "nickname_#{provider}") to prevent the duplication. But I think this should be solved in another PR.

Looking for comments and suggestions!