### PR TITLE
FIX: users#show crashing for users without email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -98,7 +98,7 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def nickname_from_email(email)
-    hash_for_email(email)
+    hash_for_email(email) if email.present?
   end
 
   def hide_nickname?

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -26,6 +26,17 @@ describe UsersController do
       get :show, params: { id: user_with_participations.id }
       expect(response).to be_ok
     end
+
+    context 'when user has no email' do
+      render_views
+
+      before { user.update!(email: nil) }
+
+      it 'does not fail' do
+        get :show, params: { id: user.id }
+        expect(response).to be_ok
+      end
+    end
   end
 
   context 'GET :edit' do


### PR DESCRIPTION
After merging #1068 there's been some errors in AppSignal when trying to show the user page for users without email
This should fix them