### PR TITLE
Update email auth to use a common OnRuby sender

### DIFF
--- a/app/controllers/concerns/with_email_auth.rb
+++ b/app/controllers/concerns/with_email_auth.rb
@@ -10,10 +10,9 @@ module WithEmailAuth
     email = normalize_email(params[:email])
     if email.present? && valid_looking_email?(email)
       token = EmailAuthToken.generate(email)
-      from = Whitelabel[:email]
       label_name = t("label.#{Whitelabel[:label_id]}.name")
       label_link = Whitelabel[:canonical_url]
-      UserMailer.login_link(email, token, from, I18n.locale,
+      UserMailer.login_link(email, token, I18n.locale,
                             label_name, label_link).deliver_later
 
       redirect_to root_path, notice: t('email_auth.email_sent', email:)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -4,14 +4,16 @@
 # Original author: https://github.com/phoet
 
 class UserMailer < ApplicationMailer
-  def login_link(email, token, from, locale, label_name, label_link) # rubocop:disable Metrics/ParameterLists
+  COMMON_SENDER = 'global@onruby.de'
+
+  def login_link(email, token, locale, label_name, label_link)
     @token = token
-    @from = from
     @label_name = label_name
     @label_link = label_link
 
     I18n.with_locale(locale) do
-      mail from: @from, to: email, subject: t('email_auth.subject', label: label_name)
+      mail from: COMMON_SENDER, to: email,
+           subject: t('email_auth.subject', label: label_name)
     end
   end
 end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -3,12 +3,11 @@ require 'spec_helper'
 describe UserMailer do
   describe '#login_link' do
     subject(:mail) do
-      described_class.login_link(email, token, from, locale, label_name, label_link).deliver_now
+      described_class.login_link(email, token, locale, label_name, label_link).deliver_now
     end
 
     let(:email) { 'user@example.com' }
     let(:token) { '12345678' }
-    let(:from) { 'no-reply@example.com' }
     let(:locale) { :en }
     let(:label_name) { 'My RUG' }
     let(:label_link) { 'http://rug.org' }
@@ -16,7 +15,7 @@ describe UserMailer do
     it 'renders the headers' do
       expect(mail.subject).to eq('Login to My RUG')
       expect(mail.to).to eq([email])
-      expect(mail.from).to eq([from])
+      expect(mail.from).to eq([UserMailer::COMMON_SENDER])
     end
 
     it 'renders the body' do


### PR DESCRIPTION
This way, we don't need to add each RUG's email address to the Sendgrid list of authorized senders.

See the conversation at #1068 for details