### PR TITLE
perf: skip roundtrip via database for organizers predicate

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,7 +45,7 @@ class User < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def organizer?
-    self.class.organizers.include? self
+    Whitelabel[:organizers].include? nickname
   end
 
   def update_from_auth!(hash)


### PR DESCRIPTION
Every User Card checks if the currently displayed user is one of the organisers to show the organiser badge. Before we used the Scope which fetches the User Objects matching the Organizer Nicknames to check if the current user is in that list. After we check if the current user nickname is part of the Organizer Nicknames, without asking the database for the users. 

Edit:
shaves off about 0.3ms per user attending. 