### PR TITLE
fix: mark ics start and end time as non floating

### DIFF
--- a/app/helpers/ical_helper.rb
+++ b/app/helpers/ical_helper.rb
@@ -7,8 +7,8 @@ module IcalHelper
       cal.event do |item|
         item.summary     = event.name
         item.description = "#{event.description} #{event_url(event)}"
-        item.dtstart     = event.date.utc
-        item.dtend       = event.end_date.utc
+        item.dtstart     = Icalendar::Values::DateTime.new event.date.utc, tzid: 'UTC'
+        item.dtend       = Icalendar::Values::DateTime.new event.end_date.utc, tzid: 'UTC'
         item.url         = event_url(event)
         item.location    = event.location.name if event.location
       end

--- a/spec/helpers/ical_helper_spec.rb
+++ b/spec/helpers/ical_helper_spec.rb
@@ -7,7 +7,7 @@ describe IcalHelper do
     helper.icalendar(event).to_s.tap do |it|
       expect(it).to match('http://test.host/events/awesome-ottawa-123')
       expect(it).to match('SUMMARY:awesome ottawa')
-      expect(it).to match('DTSTART:20111111T170000')
+      expect(it).to match('DTSTART:20111111T170000Z')
     end
   end
 


### PR DESCRIPTION
RFC-5545 Section 3.3.5. requires UTC timestamps to end with Z to not be considered a floating timestamp.
https://www.rfc-editor.org/rfc/rfc5545#section-3.3.5
