### PR TITLE
Use next event as the "current" event

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -22,7 +22,7 @@ class Event < ApplicationRecord
   default_scope       -> { where(label: Whitelabel[:label_id]) }
 
   scope :with_topics, -> { joins(:topics).distinct }
-  scope :current,     -> { where(date: Date.today.to_time..(Time.now + 9.weeks)).limit(1).order('date ASC') }
+  scope :current,     -> { where(date: Date.today.to_time..).limit(1).order('date ASC') }
   scope :latest,      -> { where('date < ?', Date.today.to_time).order('date DESC') }
   scope :unpublished, -> { where('published IS NULL') }
   scope :ordered,     -> { order('date DESC') }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -22,10 +22,10 @@ class Event < ApplicationRecord
   default_scope       -> { where(label: Whitelabel[:label_id]) }
 
   scope :with_topics, -> { joins(:topics).distinct }
-  scope :current,     -> { where(date: Date.today.to_time..).limit(1).order('date ASC') }
-  scope :latest,      -> { where('date < ?', Date.today.to_time).order('date DESC') }
+  scope :current,     -> { where(date: Date.today.to_time..).limit(1).order(date: :asc) }
+  scope :latest,      -> { where('date < ?', Date.today.to_time).order(date: :desc) }
   scope :unpublished, -> { where('published IS NULL') }
-  scope :ordered,     -> { order('date DESC') }
+  scope :ordered,     -> { order(date: :desc) }
 
   def end_date
     date + 2.hours

--- a/app/models/highlight.rb
+++ b/app/models/highlight.rb
@@ -5,7 +5,7 @@ class Highlight < ApplicationRecord
 
   default_scope -> { where(label: Whitelabel[:label_id]) }
 
-  scope :active, -> { where('end_at > ?', Time.now).order('start_at').limit(1) }
+  scope :active, -> { where('end_at > ?', Time.now).order(start_at: :asc).limit(1) }
 
   def disabled?
     end_at <= Time.now

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -24,6 +24,8 @@ describe Event do
     it 'finds a current event' do
       event_next = create(:event, date: 2.days.from_now)
       expect(Event.current.first).to eql(event_next)
+      event_next.update(date: 5.months.from_now)
+      expect(Event.current.first).to eql(event_next)
     end
   end
 


### PR DESCRIPTION
Let me know if you like the change or not. We already discussed a bit in #1084 and I feel like the artificial limit does not make much sense. If you feel like this changes behavior too much though, feel free to close this. I just had some free time and figured I create a PR for this to move forward. Maybe another solution would be better or maybe we don't want to change this at all.

This change removes the restriction of the current event to be at most 9 weeks in the future. Some user groups might decide to hold meetups less frequently so this limitation prevents them from advertising their next event until 9 weeks before the meetup.

With this change the current event that is displayed on the homepage will always be the next event, even if it's set far in the future.

Closes #1084