### PR TITLE
chore: remove kgio gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ gem 'uglifier'
 
 group :production do
   gem 'dalli'
-  gem 'kgio'
   gem 'lograge'
   gem 'rails_12factor'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,6 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    kgio (2.11.4)
     language_server-protocol (3.17.0.3)
     launchy (3.0.1)
       addressable (~> 2.8)
@@ -459,7 +458,6 @@ DEPENDENCIES
   geocoder
   icalendar
   kaminari
-  kgio
   letter_opener
   link_thumbnailer
   listen


### PR DESCRIPTION
from kgio README

```
= kgio - a legacy I/O library that did a decade of damage to Ruby

This is a legacy project has discouraged improvements to Ruby itself.
It has done a decade of harm to Ruby and continues to harm it by being
used by (unfortunately) popular projects.  Ruby 2.3 and later makes
this obsolete.  kgio provides non-blocking I/O methods for Ruby without
raising exceptions on EAGAIN and EINPROGRESS.
```
 