### PR TITLE
chore: remove rails_12factor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ group :production do
   gem 'dalli'
   gem 'kgio'
   gem 'lograge'
-  gem 'rails_12factor'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -312,11 +312,6 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (6.1.7.10)
       actionpack (= 6.1.7.10)
       activesupport (= 6.1.7.10)
@@ -477,7 +472,6 @@ DEPENDENCIES
   rack-cache
   rails (~> 6.1.3)
   rails-controller-testing
-  rails_12factor
   redcarpet
   rspec-collection_matchers
   rspec-rails


### PR DESCRIPTION
Legacy Gem, from README (already fulfilled for us): 

### Migrating to Rails 5

You can remove this gem after making sure the following sections are added in
your `production.rb` file:

**`config/environments/production.rb`**
```ruby
# Disable serving static files from the `/public` folder by default since
# Apache or NGINX already handles this.
config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?

if ENV["RAILS_LOG_TO_STDOUT"].present?
  logger           = ActiveSupport::Logger.new(STDOUT)
  logger.formatter = config.log_formatter
  config.logger = ActiveSupport::TaggedLogging.new(logger)
end
```

Make sure to add both the `RAILS_SERVE_STATIC_FILES` and `RAILS_LOG_TO_STDOUT` ENV vars and set them to `true`. (This is done for you on Heroku)
