### PR TITLE
feat: limit locations to since beginning of two years ago

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -8,7 +8,7 @@ class HomeController < ApplicationController
   expose(:upcoming_topics)  { Topic.ordered.upcoming }
   expose(:done_topics)      { Topic.ordered.done.limit(10) }
   expose(:organizers)       { User.organizers }
-  expose(:locations)        { Location.all }
+  expose(:locations)        { Location.joins(:events).merge(Event.where(date: (2.years.ago.beginning_of_year)..)).distinct }
   expose(:zoom)             { Whitelabel[:location][:zoom] }
 
   def index; end


### PR DESCRIPTION
at least for the start page. Locations Page still shows all locations. 
