### PR TITLE
fix: update canonical URLs for Barcelona and Cologne

### DIFF
--- a/config/whitelabel.yml
+++ b/config/whitelabel.yml
@@ -42,7 +42,7 @@
   coc: http://rubyberlin.github.io/code-of-conduct
 - !ruby/object:Usergroup
   label_id: cologne
-  canonical_url: https://www.colognerb.de
+  canonical_url: https://cologne.onruby.de
   status: enabled
   default_locale: de
   country: Deutschland
@@ -471,7 +471,7 @@
   twitter: bcnrails
   google_group: barcelonaonrails
   label_id: barcelona
-  canonical_url: https://ruby.barcelona
+  canonical_url: https://barcelona.onruby.eu
   status: enabled
   default_locale: es
   tld: eu

--- a/spec/requests/whitelabel_spec.rb
+++ b/spec/requests/whitelabel_spec.rb
@@ -17,12 +17,13 @@ describe 'Whitelabel' do
   end
 
   context 'GET page with custom domain' do
-    it 'shows the label' do
-      host! 'www.colognerb.de'
+    it 'shows the label and canonical' do
+      host! 'cologne.onruby.de'
 
       get root_url
       expect(response).to be_a_successful
       expect(Whitelabel[:label_id]).to eql('cologne')
+      expect(Whitelabel[:canonical_url]).to eql('https://cologne.onruby.de')
     end
   end
 end


### PR DESCRIPTION
### Description
This PR updates the outdated canonical URLs for the Barcelona and Cologne whitelabel configurations. The previous URLs were incorrect and have been replaced with the correct ones:
- Barcelona: `https://ruby.barcelona` → `https://barcelona.onruby.eu`
- Cologne: `https://www.colognerb.de` → `https://cologne.onruby.de`

Additionally, the corresponding test in `spec/requests/whitelabel_spec.rb` has been updated to:
- Reflect the new canonical URL for Cologne.
- Ensure the test validates the updated configuration.

### Changes
- Updated the `canonical_url` field in `config/whitelabel.yml` for Barcelona and Cologne.
- Updated the test in `spec/requests/whitelabel_spec.rb` to validate the new canonical URL for Cologne.

### Testing
- Ran the test suite to confirm that all tests pass successfully.
