### PR TITLE
chore: replace the deprecated sassc gem with dartsass-sprockets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Vagrantfile
 passenger.*
 .byebug_history
 .sass-cache
+node_modules

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ AllCops:
     - "app/dashboards/*"
     - "lib/tasks/*"
     - "vendor/**/*"
+    - "node_modules/**/*"
 
 Bundler/OrderedGems:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '~> 7.2.0'
 
 gem 'acts_as_api'
 gem 'addressable'
-gem 'administrate'
+gem 'administrate', '~> 1.0'
 gem 'appsignal'
 gem 'decent_exposure'
 gem 'dotenv-rails', require: 'dotenv/load'
@@ -31,8 +31,10 @@ gem 'whitelabel'
 
 # assets
 gem 'bootstrap', '~> 5.3'
+gem 'dartsass-sprockets', '~> 3.2'
 gem 'font-awesome-rails'
-gem 'sass-rails'
+gem 'jquery-rails'
+gem 'selectize-rails'
 gem 'terser'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,14 +80,11 @@ GEM
       rack (>= 1.1.0)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
-    administrate (0.20.1)
-      actionpack (>= 6.0, < 8.0)
-      actionview (>= 6.0, < 8.0)
-      activerecord (>= 6.0, < 8.0)
-      jquery-rails (~> 4.6.0)
+    administrate (1.0.0)
+      actionpack (>= 6.0, < 9.0)
+      actionview (>= 6.0, < 9.0)
+      activerecord (>= 6.0, < 9.0)
       kaminari (~> 1.2.2)
-      sassc-rails (~> 2.1)
-      selectize-rails (~> 0.6)
     anonymous_loader (0.1.3)
       version_gem (~> 1.1, >= 1.1.14)
     ansi (1.5.0)
@@ -117,6 +114,12 @@ GEM
     crass (1.0.7)
     csv (3.3.2)
     dalli (3.2.8)
+    dartsass-sprockets (3.2.1)
+      railties (>= 4.0.0)
+      sassc-embedded (~> 1.80.1)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     date (3.5.1)
     decent_exposure (3.0.4)
       activesupport (>= 4.0)
@@ -152,6 +155,9 @@ GEM
       csv (>= 3.0.0)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    google-protobuf (4.36.0)
+      bigdecimal
+      rake (~> 13.3)
     hashdiff (1.2.1)
     hashie (5.1.0)
       logger
@@ -175,7 +181,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     iso8601 (0.13.0)
-    jquery-rails (4.6.0)
+    jquery-rails (4.6.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -417,16 +423,11 @@ GEM
       ansi
       ast
     ruby-progressbar (1.13.0)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
+    sass-embedded (1.103.1)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sassc-embedded (1.80.9)
+      sass-embedded (~> 1.80)
     securerandom (0.4.1)
     selectize-rails (0.12.6)
     simple_form (5.3.1)
@@ -497,11 +498,12 @@ PLATFORMS
 DEPENDENCIES
   acts_as_api
   addressable
-  administrate
+  administrate (~> 1.0)
   appsignal
   bootstrap (~> 5.3)
   byebug
   dalli
+  dartsass-sprockets (~> 3.2)
   decent_exposure
   dotenv-rails
   factory_bot_rails
@@ -509,6 +511,7 @@ DEPENDENCIES
   font-awesome-rails
   geocoder
   icalendar
+  jquery-rails
   kaminari
   letter_opener
   link_thumbnailer
@@ -532,7 +535,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   rubocop-rspec
-  sass-rails
+  selectize-rails
   simple_form
   slim-rails
   sprockets (~> 4.0)

--- a/app/assets/stylesheets/administrate/custom.css
+++ b/app/assets/stylesheets/administrate/custom.css
@@ -1,0 +1,23 @@
+.pagination {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  list-style: none;
+  padding: 0;
+  margin-top: 2em;
+
+  .page-item,
+  li {
+    display: inline-block;
+    margin: 0 0.2em;
+  }
+
+  .page-link,
+  a,
+  span {
+    display: inline-block;
+    padding: 0.375rem 0.75rem;
+    text-decoration: none;
+  }
+}

--- a/app/views/admin/events/_collection.html.erb
+++ b/app/views/admin/events/_collection.html.erb
@@ -45,8 +45,8 @@ to display a collection of resources in an HTML table.
           <% end %>
         </th>
       <% end %>
-      <% [valid_action?(:edit, collection_presenter.resource_name),
-          valid_action?(:destroy, collection_presenter.resource_name)].count(true).times do %>
+      <% [accessible_action?(new_resource, :edit),
+          accessible_action?(new_resource, :destroy)].count(true).times do %>
         <th scope="col"></th>
       <% end %>
     </tr>
@@ -56,13 +56,13 @@ to display a collection of resources in an HTML table.
     <% resources.each do |resource| %>
       <tr class="js-table-row"
           tabindex="0"
-          <% if valid_action? :show, collection_presenter.resource_name %>
+          <% if accessible_action?(resource, :show) %>
             <%= %(role=link data-url=#{polymorphic_path([namespace, resource])}) %>
           <% end %>
           >
         <% collection_presenter.attributes_for(resource).each do |attribute| %>
           <td class="cell-data cell-data--<%= attribute.html_class %>">
-            <% if show_action? :show, resource -%>
+            <% if accessible_action?(resource, :show) -%>
               <a href="<%= polymorphic_path([namespace, resource]) -%>"
                  class="action-show"
                  >
@@ -72,22 +72,22 @@ to display a collection of resources in an HTML table.
           </td>
         <% end %>
 
-        <% if valid_action? :edit, collection_presenter.resource_name %>
+        <% if accessible_action?(resource, :edit) %>
           <td><%= link_to(
             t("administrate.actions.edit"),
             [:edit, namespace, resource],
             class: "action-edit",
-          ) if show_action? :edit, resource%></td>
+          ) %></td>
         <% end %>
 
-        <% if valid_action? :destroy, collection_presenter.resource_name %>
+        <% if accessible_action?(resource, :destroy) %>
           <td><%= link_to(
             t("administrate.actions.destroy"),
             [namespace, resource],
             class: "text-color-red",
             method: :delete,
             data: { confirm: t("administrate.actions.confirm") }
-          ) if show_action? :destroy, resource %></td>
+          ) %></td>
         <% end %>
       </tr>
     <% end %>

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -49,7 +49,7 @@ It renders the `_table` partial to display details about the resources.
       duplicate_admin_events_path,
       class: "button",
       method: :post,
-    ) if valid_action?(:new) && show_action?(:new, new_resource) %>
+    ) if accessible_action?(new_resource, :new) %>
 
     <%= link_to(
       t(
@@ -58,7 +58,7 @@ It renders the `_table` partial to display details about the resources.
       ),
       [:new, namespace, page.resource_path.to_sym],
       class: "button",
-    ) if valid_action?(:new) && show_action?(:new, new_resource) %>
+    ) if accessible_action?(new_resource, :new) %>
   </div>
 </header>
 

--- a/app/views/admin/events/show.html.erb
+++ b/app/views/admin/events/show.html.erb
@@ -28,7 +28,7 @@ as well as a link to its edit page.
       t("administrate.actions.edit_resource", name: page.page_title),
       [:edit, namespace, page.resource],
       class: "button",
-    ) if valid_action?(:edit) && show_action?(:edit, page.resource) %>
+    ) if accessible_action?(page.resource, :edit) %>
   </div>
 </header>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,7 @@
 require_relative "boot"
 
 # remove active-storage so the fucker won't try to load the config
-%w(
+%w[
   active_record/railtie
   action_controller/railtie
   action_view/railtie
@@ -9,7 +9,7 @@ require_relative "boot"
   active_job/railtie
   rails/test_unit/railtie
   sprockets/railtie
-).each do |railtie|
+].each do |railtie|
   require railtie
 end
 
@@ -50,5 +50,8 @@ module OnRuby
       g.fixture_replacement :factory_bot, dir: 'spec/support/factories'
       g.stylesheet_engine = :sass
     end
+
+    config.sass.quiet_deps = true
+    config.sass.silence_deprecations = ['import']
   end
 end

--- a/config/initializers/administrate.rb
+++ b/config/initializers/administrate.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Administrate::Engine.add_stylesheet("administrate/custom")

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_13_033955) do
-
+ActiveRecord::Schema[7.2].define(version: 2021_01_13_033955) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -147,5 +146,4 @@ ActiveRecord::Schema.define(version: 2021_01_13_033955) do
     t.string "linkedin"
     t.index ["nickname"], name: "index_users_on_nickname", unique: true
   end
-
 end


### PR DESCRIPTION
# More modern tooling

> **Motivation**
> I wanted to have a look at the good ol' on_ruby code and give it a refresh, but couldn't even run `bundle install` as `sassc` and `libsass` are soo deprecated. So I decided to remove this blocker first. It was obviously a bit more involved than hoped for, but I did the minimal amount of changes.

* **deprecated and removed:** https://github.com/sass/sassc-rails
* **drop-in replacement:** https://github.com/tablecheck/dartsass-sprockets (wraps Dart Sass)

## Administrate

administrate had to be updated from `0.20.1` to `1.0.0` as the old version had `sassc` as explicit dependency.

Their maintainers realized this issue years ago and overhauled their asset handling completely:

* https://github.com/thoughtbot/administrate/issues/2091

The code changes were minimal. The `valid_action?` & `show_action?` methods have been replaced by `accessible_action?`.  

## Evaluating the changes

* Please have a look at `app/views/admin/events/_collection.html.erb` and in particular at the handling of the **destroy** buttons to ensure the behavior did not change.
* The tests do pass, but I was unable to check the "before" behavior in the browser.
* Please test the app in the browser on your machine, as I haven't seen it in a long time and wouldn't know how broken looks.

## Disclaimer

I did not try the Docker setup, but run it locally.