### PR TITLE
Fix geocoding

### DIFF
--- a/app/assets/javascripts/map.js
+++ b/app/assets/javascripts/map.js
@@ -18,6 +18,7 @@ class GMap {
     const contents = {};
 
     jQuery.each(this.data, function() {
+      if (this.lat == null || this.long == null) { return; } // skip ungeocoded locations (avoid 0,0 "ocean" pin)
       const position = new google.maps.LatLng(this.lat, this.long);
       const marker = new google.maps.Marker({position, map, title: this.name});
       let content = `<div class='info-window'><p><strong><a href='/locations/${this.slug}'>${this.name}</a></strong></br>`;

--- a/app/helpers/map_helper.rb
+++ b/app/helpers/map_helper.rb
@@ -2,6 +2,7 @@
 
 module MapHelper
   def static_map(*locations)
+    locations = locations.select(&:geocoded?)
     options = {
       zoom: 12,
       sensor: false,
@@ -14,6 +15,8 @@ module MapHelper
   end
 
   def single_map(location, init = { zoom: 14 })
+    return unless location&.geocoded?
+
     data = {
       map: Array(location).to_json,
       init: location.attributes.merge(init).to_json,
@@ -22,6 +25,7 @@ module MapHelper
   end
 
   def map(locations, init = { zoom: 12 })
+    locations = locations.select(&:geocoded?)
     init = Whitelabel[:location].merge(init)
     data = {
       map: locations.to_json,

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -11,6 +11,17 @@ Geocoder.configure(
   # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
   # cache_prefix: 'geocoder:',  # prefix (string) to use for all cache keys
 
+  # Our default lookup is Nominatim (OpenStreetMap).
+  # Its usage policy (https://operations.osmfoundation.org/policies/nominatim/)
+  # requires every client to identify itself via a valid User-Agent (or Referer).
+  # Without this header access is denied, location silently stay `nil`/`nil`.
+  #
+  # We use a custom User-Agent that includes the domain and email address of the
+  # user who is requesting the geocoding.
+  http_headers: {
+    'User-Agent' => 'on_ruby (https://www.onruby.eu/)',
+  },
+
   # Exceptions that should not be rescued by default
   # (if you want to implement custom error handling);
   # supports SocketError and Timeout::Error

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -16,8 +16,8 @@ Geocoder.configure(
   # requires every client to identify itself via a valid User-Agent (or Referer).
   # Without this header access is denied, location silently stay `nil`/`nil`.
   #
-  # We use a custom User-Agent that includes the domain and email address of the
-  # user who is requesting the geocoding.
+  # We use a custom User-Agent identifying the platform, which should be fine
+  # given our traffic.
   http_headers: {
     'User-Agent' => 'on_ruby (https://www.onruby.eu/)',
   },

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -26,7 +26,7 @@ Whitelabel.with_label(label) do
   # real location, so we can geocode it
   location = Location.find_or_create_by!(name: 'Seeded Location', label: label.label_id) do |loc|
     loc.url          = 'http://example.com'
-    loc.street       = 'Platz d. Deutschen Einheit'
+    loc.street       = 'Platz der Deutschen Einheit'
     loc.house_number = '4'
     loc.city         = 'Hamburg'
     loc.zip          = '20457'


### PR DESCRIPTION
We noticed on RUG::B that our latest locations weren't geocoded/ ended up in the middle of the ocean which was a bit odd.

After looking into it, turns out that's due to the geocoding service used here requiring an HTTP header to identify yourself.

So, that was added along with a couple of fail safes against the `nil`/`nil` -> 0/0 rendering.

Based on the dev setup branch/#1209 since I needed those changes here. So PR made against that branch for now, to just see those changes.